### PR TITLE
Add `@automerge/automerge-wasm` dependency explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@automerge/automerge-repo-network-websocket": "1.0.19",
     "@automerge/automerge-repo-react-hooks": "1.0.19",
     "@automerge/automerge-repo-storage-indexeddb": "1.0.19",
+    "@automerge/automerge-wasm": "^0.9.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "vite-plugin-top-level-await": "^1.3.1",


### PR DESCRIPTION
Otherwise, when using `pnpm`, I have the following issue when running `pnpm run dev`:

<img width="913" alt="image" src="https://github.com/automerge/automerge-repo-quickstart/assets/804625/abf62add-cf96-49c5-95fd-e25da8a519c6">
